### PR TITLE
adding a semicolon that rustc wanted really badly

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -69,7 +69,7 @@ impl Args {
         unsafe {
             let k = CString::new(key).expect("SoapySDR key can't contain null bytes");
             let v = CString::new(value).expect("SoapySDR value can't contain null bytes");
-            SoapySDRKwargs_set(self.as_raw(), k.as_ptr(), v.as_ptr())
+            SoapySDRKwargs_set(self.as_raw(), k.as_ptr(), v.as_ptr());
         }
     }
 


### PR DESCRIPTION
It appears SoapySDR changed a return type, adding an `i32` return for `SoapySDRKwargs_set`.  The right thing here would be to actually propagate the added error code, but I'm not sure what would be a preferred way to do so.  For now this will at least make it compile (and it shouldn't break building against older versions either).
