### PR TITLE
Bump num-complex to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [dependencies]
 soapysdr-sys = { version = "0.6.0", path = "./soapysdr-sys" }
 libc = "0.2.20"
-num-complex = "0.1.37"
+num-complex = "0.2"
 log = { version = "0.3", optional = true }
 
 # Dependencies used only by binaries


### PR DESCRIPTION
Bumps num_complex up to 0.2, as the trait implementations are currently for 0.1.* and incompatible with code using 0.2.