### PR TITLE
use pkg-config -I flags to find SoapySDR headers

### DIFF
--- a/soapysdr-sys/build.rs
+++ b/soapysdr-sys/build.rs
@@ -5,14 +5,21 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    if let Err(e) = pkg_config::Config::new().atleast_version("0.6.0").probe("SoapySDR") {
-        panic!("Couldn't find SoapySDR: {}", e);
-    }
+    let lib = match pkg_config::Config::new().atleast_version("0.6.0").probe("SoapySDR") {
+        Err(e) => panic!("Couldn't find SoapySDR: {}", e),
+        Ok(lib) => lib,
+    };
 
-    let bindings = bindgen::Builder::default()
+    let mut bindings = bindgen::Builder::default()
         .trust_clang_mangling(false)
-        .header("wrapper.h")
-        .generate()
+        .header("wrapper.h");
+    
+    for inc in lib.include_paths {
+        let inc_str = inc.to_str().expect("PathBuf to string conversion problem");
+        bindings = bindings.clang_arg("-I".to_owned() + inc_str);
+    }
+    
+    let bindings = bindings.generate()
         .expect("Unable to generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());


### PR DESCRIPTION
This allows soapysdr-sys to build when SoapySDR was installed with a prefix that isn't /usr, /usr/local, etc.