### PR TITLE
Soapy 0.8 support

### DIFF
--- a/soapysdr-sys/Cargo.toml
+++ b/soapysdr-sys/Cargo.toml
@@ -20,4 +20,5 @@ repository = "https://github.com/kevinmehall/rust-soapysdr"
 
 [build-dependencies]
 bindgen = "0.51"
+cc = "1.0"
 pkg-config = "0.3.9"

--- a/soapysdr-sys/build.rs
+++ b/soapysdr-sys/build.rs
@@ -1,4 +1,5 @@
 extern crate bindgen;
+extern crate cc;
 extern crate pkg_config;
 
 use std::env;
@@ -10,20 +11,27 @@ fn main() {
         Ok(lib) => lib,
     };
 
-    let mut bindings = bindgen::Builder::default()
+    let mut bindgen_builder = bindgen::Builder::default()
         .trust_clang_mangling(false)
         .header("wrapper.h");
-    
+
+    let mut cc_builder = cc::Build::new();
+    cc_builder.file("wrapper.c");
+
     for inc in lib.include_paths {
-        let inc_str = inc.to_str().expect("PathBuf to string conversion problem");
-        bindings = bindings.clang_arg("-I".to_owned() + inc_str);
+        let inc_str = &inc.to_str().expect("PathBuf to string conversion problem");
+        bindgen_builder = bindgen_builder.clang_arg("-I".to_owned() + inc_str);
+
+        cc_builder.include(&inc);
     }
-    
-    let bindings = bindings.generate()
+
+    let bindings = bindgen_builder.generate()
         .expect("Unable to generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
+
+    cc_builder.compile("soapysdr-sys-wrappers");
 }

--- a/soapysdr-sys/build.rs
+++ b/soapysdr-sys/build.rs
@@ -5,14 +5,21 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    if let Err(e) = pkg_config::Config::new().atleast_version("0.6.0").probe("SoapySDR") {
-        panic!("Couldn't find SoapySDR: {}", e);
-    }
+    let lib = match pkg_config::Config::new().atleast_version("0.6.0").probe("SoapySDR") {
+        Err(e) => panic!("Couldn't find SoapySDR: {}", e),
+        Ok(lib) => lib,
+    };
 
-    let bindings = bindgen::Builder::default()
+    let mut bindings = bindgen::Builder::default()
         .trust_clang_mangling(false)
-        .header("wrapper.h")
-        .generate()
+        .header("wrapper.h");
+    
+    for inc in lib.include_paths {
+        let inc_str = inc.to_str().expect("PathBuf to string conversion problem");
+        bindings = bindings.clang_arg("-I".to_owned() + inc_str);
+    }
+    
+    let bindings = bindings.generate()
         .expect("Unable to generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/soapysdr-sys/wrapper.c
+++ b/soapysdr-sys/wrapper.c
@@ -1,0 +1,18 @@
+#include "wrapper.h"
+
+int _rust_wrapper_SoapySDRDevice_setupStream(
+    SoapySDRDevice *device,
+    SoapySDRStream **out_stream,
+    int direction,
+    char const* format,
+    size_t const*channels,
+    size_t numChans,
+    SoapySDRKwargs const* args)
+{
+#if SOAPY_SDR_API_VERSION < 0x00080000
+    return SoapySDRDevice_setupStream(device, out_stream, direction, format, channels, numChans, args);
+#else
+    *out_stream = SoapySDRDevice_setupStream(device, direction, format, channels, numChans, args);
+    return SoapySDRDevice_lastStatus();
+#endif
+}

--- a/soapysdr-sys/wrapper.h
+++ b/soapysdr-sys/wrapper.h
@@ -4,3 +4,12 @@
 #include <SoapySDR/Modules.h>
 #include <SoapySDR/Time.h>
 #include <SoapySDR/Version.h>
+
+int _rust_wrapper_SoapySDRDevice_setupStream(
+    SoapySDRDevice *device,
+    SoapySDRStream **out_stream,
+    int direction,
+    char const* format,
+    size_t const*channels,
+    size_t numChans,
+    SoapySDRKwargs const* args);

--- a/src/device.rs
+++ b/src/device.rs
@@ -376,7 +376,7 @@ impl Device {
     pub fn rx_stream_args<E: StreamSample, A: Into<Args>>(&self, channels: &[usize], args: A) -> Result<RxStream<E>, Error> {
         unsafe {
             let mut stream: *mut SoapySDRStream = ptr::null_mut();
-            check_error(SoapySDRDevice_setupStream(self.inner.ptr,
+            check_error(_rust_wrapper_SoapySDRDevice_setupStream(self.inner.ptr,
                 &mut stream as *mut _,
                 Direction::Rx.into(),
                 E::STREAM_FORMAT.as_ptr(),
@@ -403,7 +403,7 @@ impl Device {
     pub fn tx_stream_args<E: StreamSample, A: Into<Args>>(&self, channels: &[usize], args: A) -> Result<TxStream<E>, Error> {
         unsafe {
             let mut stream: *mut SoapySDRStream = ptr::null_mut();
-            check_error(SoapySDRDevice_setupStream(self.inner.ptr,
+            check_error(_rust_wrapper_SoapySDRDevice_setupStream(self.inner.ptr,
                 &mut stream as *mut _,
                 Direction::Tx.into(),
                 E::STREAM_FORMAT.as_ptr(),


### PR DESCRIPTION
[builds on #14 because that was necessary in my environment]

Adds support for new setupStream API, in a way which _should_ be backward compatible