### PR TITLE
Update num-complex dependency from 0.2 to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [dependencies]
 soapysdr-sys = { version = "0.7.0", path = "./soapysdr-sys" }
 libc = "0.2.20"
-num-complex = "0.2"
+num-complex = "0.4"
 log = { version = "0.3", optional = true }
 
 # Dependencies used only by binaries


### PR DESCRIPTION
I ran into an error that looked like this:

```
error[E0277]: the trait bound `Complex<f32>: StreamSample` is not satisfied
   --> src/main.rs:15:46
    |
15  |     let mut stream: RxStream<Complex<f32>> = dev.rx_stream::<Complex<f32>>(&[0]).unwrap();
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `StreamSample` is not implemented for `Complex<f32>`
    | 
```

Turns out it was just a version mismatch with `complex-num`.

Release notes here: https://github.com/rust-num/num-complex/blob/master/RELEASES.md