### PR TITLE
Add Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ readme = "README.md"
 
 [dependencies]
 soapysdr-sys = { version = "0.7.2", path = "./soapysdr-sys" }
-libc = "0.2.20"
 num-complex = "0.4"
 log = { version = "0.4", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ nix-shell
 
 (see [shell.nix](./shell.nix))
 
+### Windows
+
+Install pre-built PothosSDR and LLVM, then
+
+  - Set `LIBCLANG_PATH` environment variable to LLVM bin directory for rust-bindgen
+  - Add PothosSDR bin directory to system `PATH`
+
 ## Warning
 
 Many SoapySDR driver modules have error handling and thread safety bugs. This library provides

--- a/soapysdr-sys/Cargo.toml
+++ b/soapysdr-sys/Cargo.toml
@@ -19,6 +19,6 @@ repository = "https://github.com/kevinmehall/rust-soapysdr"
 [dependencies]
 
 [build-dependencies]
-bindgen = { version = "0.57.0", default-features = false }
+bindgen = { version = "0.57.0", default-features = false, features = ["runtime"] }
 cc = "1.0"
 pkg-config = "0.3.9"

--- a/soapysdr-sys/build.rs
+++ b/soapysdr-sys/build.rs
@@ -5,11 +5,43 @@ extern crate pkg_config;
 use std::env;
 use std::path::PathBuf;
 
+fn probe_pkg_config() -> Option<Vec<PathBuf>> {
+    match pkg_config::Config::new()
+        .atleast_version("0.6.0")
+        .probe("SoapySDR")
+    {
+        Err(e) => {
+            eprintln!("pkg_config: {}", e);
+            None
+        }
+        Ok(lib) => Some(lib.include_paths),
+    }
+}
+
+// Find PothosSDR in paths in windows
+fn probe_pothos_sdr() -> Option<Vec<PathBuf>> {
+    #[cfg(windows)]
+    {
+        let lib = "SoapySDR";
+        let dll = lib.to_owned() + ".dll";
+        let paths = env::var_os("PATH")?;
+        for dir in env::split_paths(&paths) {
+            let dll_path = dir.join(&dll);
+            let inc_path = dir.join("../include");
+            if dll_path.is_file() && inc_path.is_dir() {
+                println!("cargo:rustc-link-search={}", dir.to_str().unwrap());
+                println!("cargo:rustc-link-lib={}", lib);
+                return Some(vec![inc_path]);
+            }
+        }
+    }
+    None
+}
+
 fn main() {
-    let lib = match pkg_config::Config::new().atleast_version("0.6.0").probe("SoapySDR") {
-        Err(e) => panic!("Couldn't find SoapySDR: {}", e),
-        Ok(lib) => lib,
-    };
+    let include_paths = probe_pkg_config()
+        .or_else(|| probe_pothos_sdr())
+        .expect("Couldn't find SoapySDR");
 
     let mut bindgen_builder = bindgen::Builder::default()
         .trust_clang_mangling(false)
@@ -19,7 +51,7 @@ fn main() {
     let mut cc_builder = cc::Build::new();
     cc_builder.file("wrapper.c");
 
-    for inc in lib.include_paths {
+    for inc in include_paths {
         let inc_str = &inc.to_str().expect("PathBuf to string conversion problem");
         bindgen_builder = bindgen_builder.clang_arg("-I".to_owned() + inc_str);
 

--- a/soapysdr-sys/wrapper.c
+++ b/soapysdr-sys/wrapper.c
@@ -1,4 +1,5 @@
 #include "wrapper.h"
+#include <stdlib.h>
 
 int _rust_wrapper_SoapySDRDevice_setupStream(
     SoapySDRDevice *device,
@@ -16,3 +17,9 @@ int _rust_wrapper_SoapySDRDevice_setupStream(
     return SoapySDRDevice_lastStatus();
 #endif
 }
+
+#if SOAPY_SDR_API_VERSION < 0x00080000
+void SoapySDR_free(void *ptr){
+    free(ptr);
+}
+#endif

--- a/soapysdr-sys/wrapper.h
+++ b/soapysdr-sys/wrapper.h
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <SoapySDR/Device.h>
 #include <SoapySDR/Logger.h>
 #include <SoapySDR/Formats.h>
@@ -13,3 +14,7 @@ int _rust_wrapper_SoapySDRDevice_setupStream(
     size_t const*channels,
     size_t numChans,
     SoapySDRKwargs const* args);
+
+#if SOAPY_SDR_API_VERSION < 0x00080000
+void SoapySDR_free(void *ptr);
+#endif

--- a/src/arginfo.rs
+++ b/src/arginfo.rs
@@ -4,14 +4,26 @@ use std::ptr;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-#[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ArgType {
-    Bool = SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_BOOL,
-    Float = SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_FLOAT,
-    Int = SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_INT,
-    String = SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_STRING,
+    Bool,
+    Float,
+    Int,
+    String,
     __Nonexhaustive,
+}
+
+impl From<SoapySDRArgInfoType> for ArgType {
+    #[allow(non_upper_case_globals)]
+    fn from(arg_info_type: SoapySDRArgInfoType) -> Self {
+        match arg_info_type {
+            SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_BOOL => ArgType::Bool,
+            SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_FLOAT => ArgType::Float,
+            SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_INT => ArgType::Int,
+            SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_STRING => ArgType::String,
+            _ => ArgType::__Nonexhaustive,
+        }
+    }
 }
 
 /// Metadata about supported arguments.
@@ -53,7 +65,6 @@ unsafe fn optional_string(s: *mut c_char) -> Option<String> {
     }
 }
 
-#[allow(non_upper_case_globals)]
 pub unsafe fn arg_info_from_c(c: &SoapySDRArgInfo) -> ArgInfo {
     ArgInfo {
         key:         required_string(c.key),
@@ -61,13 +72,7 @@ pub unsafe fn arg_info_from_c(c: &SoapySDRArgInfo) -> ArgInfo {
         name:        optional_string(c.name),
         description: optional_string(c.description),
         units:       optional_string(c.units),
-        data_type:   match c.type_ {
-            SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_BOOL => ArgType::Bool,
-            SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_FLOAT => ArgType::Float,
-            SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_INT => ArgType::Int,
-            SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_STRING => ArgType::String,
-            _ => ArgType::__Nonexhaustive,
-        },
+        data_type:   c.type_.into(),
         options: {
             let option_vals = slice::from_raw_parts(c.options, c.numOptions);
             let option_names = slice::from_raw_parts(c.optionNames, c.numOptions);

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,12 +1,11 @@
 use soapysdr_sys::*;
 pub use soapysdr_sys::SoapySDRRange as Range;
-use libc;
 use std::slice;
 use std::ptr;
 use std::sync::Arc;
 use std::ffi::{ CStr, CString };
 use std::os::raw::{c_int, c_char};
-use libc::c_void;
+use std::os::raw::c_void;
 use std::marker::PhantomData;
 
 use super::{ Args, ArgInfo, StreamSample, Format };
@@ -177,7 +176,7 @@ fn len_result(ret: c_int) -> Result<c_int, Error> {
 unsafe fn string_result(r: *mut c_char) -> Result<String, Error> {
     let ptr: *mut c_char = check_error(r)?;
     let ret = CStr::from_ptr(ptr).to_string_lossy().into();
-    libc::free(ptr as *mut c_void);
+    SoapySDR_free(ptr as *mut c_void);
     Ok(ret)
 }
 
@@ -203,7 +202,7 @@ unsafe fn list_result<T: Copy, F: FnOnce(*mut usize) -> *mut T>(f: F) -> Result<
     let mut len: usize = 0;
     let ptr = check_error(f(&mut len as *mut _))?;
     let ret = slice::from_raw_parts(ptr, len).to_owned();
-    libc::free(ptr as *mut c_void);
+    SoapySDR_free(ptr as *mut c_void);
     Ok(ret)
 }
 
@@ -232,7 +231,7 @@ pub fn enumerate<A: Into<Args>>(args: A) -> Result<Vec<Args>, Error> {
         let mut len: usize = 0;
         let devs = check_error(SoapySDRDevice_enumerate(args.into().as_raw_const(), &mut len as *mut _))?;
         let args = slice::from_raw_parts(devs, len).iter().map(|&arg| Args::from_raw(arg)).collect();
-        libc::free(devs as *mut c_void);
+        SoapySDR_free(devs as *mut c_void);
         Ok(args)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 //!
 
 extern crate soapysdr_sys;
-extern crate libc;
 extern crate num_complex;
 #[cfg(feature="log")] #[macro_use] extern crate log;
 
@@ -27,7 +26,7 @@ pub use format::{Format, StreamSample};
 pub fn configure_logging() {
     use log::Level;
     use soapysdr_sys::*;
-    use libc::c_char;
+    use std::os::raw::c_char;
     use std::ffi::CStr;
 
     extern "C" fn soapy_log(level: SoapySDRLogLevel, message: *const c_char) {


### PR DESCRIPTION
Allow rust-soapysdr to work on Windows.

## Changes

### SoapySDR_free / libc
Remove libc dependency and change from libc::free to SoapySDR_free from SoapySDR 0.8.
libc::free was crashing on my platform probably due to linking with different libc.

### ArgType
Remove enum discriminant from arginfo::ArgType.
SoapySDRArgInfoType_SOAPY_SDR_ARG_INFO_* constant in my platform are i32 instead of u32. Nothing are using these values, so I removed them.

### soapysdr-sys
Add library searching from path variable for Windows platform, it should be compatible with both pre-built PothosSDR and SoapySDR compiled from source.
Add stdbool.h because my compiler complains about bool.

## Testing
Works fine Windows 10 + PothosSDR 2021.07.25 (soapysdr 0.8)
Builds okay on ubuntu + soapysdr 0.7.2 but not tested