### PR TITLE
Add read/write setting functions

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -835,12 +835,10 @@ impl Device {
 
     // TODO: registers
 
-    // TODO: settings
-
     /// Write a setting
     pub fn write_setting<S: Into<Vec<u8>>>(&self, key: S, value: S) -> Result<(), Error> {
-        let key = CString::new(key).expect("key must contain null byte");
-        let value = CString::new(value).expect("value must contain null byte");
+        let key = CString::new(key).expect("key must not contain null byte");
+        let value = CString::new(value).expect("value must not contain null byte");
         unsafe {
             check_ret_error(SoapySDRDevice_writeSetting(self.inner.ptr, key.as_ptr(), value.as_ptr()))?;
             Ok(())
@@ -849,7 +847,7 @@ impl Device {
 
     /// Read a setting
     pub fn read_setting<S: Into<Vec<u8>>>(&self, key: S) -> Result<String, Error> {
-        let key = CString::new(key).expect("key must contain null byte");
+        let key = CString::new(key).expect("key must not contain null byte");
         unsafe {
             string_result(SoapySDRDevice_readSetting(self.inner.ptr, key.as_ptr()))
         }

--- a/src/device.rs
+++ b/src/device.rs
@@ -837,6 +837,24 @@ impl Device {
 
     // TODO: settings
 
+    /// Write a setting
+    pub fn write_setting<S: Into<Vec<u8>>>(&self, key: S, value: S) -> Result<(), Error> {
+        let key = CString::new(key).expect("key must contain null byte");
+        let value = CString::new(value).expect("value must contain null byte");
+        unsafe {
+            check_ret_error(SoapySDRDevice_writeSetting(self.inner.ptr, key.as_ptr(), value.as_ptr()))?;
+            Ok(())
+        }
+    }
+
+    /// Read a setting
+    pub fn read_setting<S: Into<Vec<u8>>>(&self, key: S) -> Result<String, Error> {
+        let key = CString::new(key).expect("key must contain null byte");
+        unsafe {
+            string_result(SoapySDRDevice_readSetting(self.inner.ptr, key.as_ptr()))
+        }
+    }
+
     // TODO: gpio
 
     // TODO: I2C


### PR DESCRIPTION
Add `write_setting` and `read_setting`. Currently used/tested in the following project/MR: https://github.com/rsadsb/dump1090_rs/pull/17

Thanks for the project!