### PR TITLE
Allow overriding location of SoapySDR during build

### DIFF
--- a/soapysdr-sys/build.rs
+++ b/soapysdr-sys/build.rs
@@ -7,15 +7,14 @@ use std::env::consts;
 use std::path::PathBuf;
 
 fn probe_env_var() -> Option<Vec<PathBuf>> {
-    let paths = env::var_os("SOAPYSDR_LIB_DIR")?;
-    for lib_path in env::split_paths(&paths) {
+    let paths = env::var_os("SOAPY_SDR_ROOT")?;
+    for path in env::split_paths(&paths) {
         let dylib_name = format!("{}SoapySDR{}", consts::DLL_PREFIX, consts::DLL_SUFFIX);
-        let inc_path = lib_path.join("../include");
+        let inc_path = path.join("./include");
+        let lib_path = path.join("./lib");
 
-        if inc_path.is_dir() && lib_path.join(dylib_name).exists() {
-            if lib_path.is_dir() {
-                println!("cargo:rustc-link-search={}", lib_path.to_str().unwrap());
-            }
+        if lib_path.is_dir() && inc_path.is_dir() && lib_path.join(dylib_name).exists() {
+            println!("cargo:rustc-link-search={}", lib_path.to_str().unwrap());
             println!("cargo:rustc-link-lib=SoapySDR");
 
             return Some(vec![inc_path]);

--- a/soapysdr-sys/build.rs
+++ b/soapysdr-sys/build.rs
@@ -7,7 +7,7 @@ use std::env::consts;
 use std::path::PathBuf;
 
 fn probe_env_var() -> Option<Vec<PathBuf>> {
-    let paths = env::var_os("SOAPY_SDR_ROOT")?;
+    let paths = env::var_os("SOAPY_SDR_ROOT").or_else(|| env::var_os("SoapySDR_DIR"))?;
     for path in env::split_paths(&paths) {
         let dylib_name = format!("{}SoapySDR{}", consts::DLL_PREFIX, consts::DLL_SUFFIX);
         let inc_path = path.join("./include");

--- a/soapysdr-sys/build.rs
+++ b/soapysdr-sys/build.rs
@@ -63,8 +63,8 @@ fn probe_pothos_sdr() -> Option<Vec<PathBuf>> {
 
 fn main() {
     let include_paths = probe_env_var()
-        .or_else(|| probe_pkg_config())
-        .or_else(|| probe_pothos_sdr())
+        .or_else(probe_pkg_config)
+        .or_else(probe_pothos_sdr)
         .expect("Couldn't find SoapySDR");
 
     let mut bindgen_builder = bindgen::Builder::default()


### PR DESCRIPTION
Mostly just a copy and paste of a snippet from https://kornel.ski/rust-sys-crate
