### PR TITLE
Support Windows in soapy-sdr-stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ log = { version = "0.4", optional = true }
 # (https://github.com/rust-lang/cargo/issues/1982)
 byteorder = { version = "1.1", optional = true }
 getopts = { version = "0.2.4", optional = true }
-signalbool = { version = "0.2.0", optional = true }
+ctrlc = { version = "3.4.0", optional = true }
 
 [features]
 default = ["log"]
-binaries = ["byteorder", "getopts", "signalbool"]
+binaries = ["byteorder", "getopts", "ctrlc"]
 
 [[bin]]
 name = "soapy-sdr-info"

--- a/src/bin/soapy-sdr-stream.rs
+++ b/src/bin/soapy-sdr-stream.rs
@@ -1,21 +1,21 @@
-extern crate soapysdr;
-extern crate num_complex;
 extern crate byteorder;
-extern crate getopts;
 extern crate ctrlc;
+extern crate getopts;
+extern crate num_complex;
+extern crate soapysdr;
 
-use std::env;
-use std::cmp::min;
-use std::fs::File;
-use std::io::{self, BufReader, BufWriter, Read, Write, ErrorKind};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::i64;
-use std::process;
-use byteorder::{ WriteBytesExt, LittleEndian, ByteOrder };
-use soapysdr::Direction::{Rx, Tx};
+use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use getopts::Options;
 use num_complex::Complex;
+use soapysdr::Direction::{Rx, Tx};
+use std::cmp::min;
+use std::env;
+use std::fs::File;
+use std::i64;
+use std::io::{self, BufReader, BufWriter, ErrorKind, Read, Write};
+use std::process;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 fn main() {
     let mut args = env::args();


### PR DESCRIPTION
Currently soapy-sdr-stream cannnot be built on Windows because Windows does not have signals.
This is breaking https://github.com/kevinmehall/rust-soapysdr/pull/28 which added building soapy-sdr-stream on CI (it wasn't before)
Because it is just `SIGINT` that we are handling, the `ctrlc` crate is a suitable cross-platform replacement for `signalbool`.