### PR TITLE
Fix and test soapy-sdr-stream example binary on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends libsoapysdr-dev libclang-dev llvm-dev pkg-config
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build
+      run: cargo build --all-features
     - name: Run tests
       run: cargo test
 
@@ -36,7 +36,7 @@ jobs:
         echo "C:\\msys64\\mingw64\\bin" >> $GITHUB_PATH
     - name: Build
       shell: bash
-      run: cargo build
+      run: cargo build --all-features
     - name: Run tests
       shell: bash
       run: cargo test

--- a/src/bin/soapy-sdr-stream.rs
+++ b/src/bin/soapy-sdr-stream.rs
@@ -108,8 +108,8 @@ fn main() {
     });
 
     let sb = signalbool::SignalBool::new(
-        &[signalbool::Signal::SIGINT], signalbool::Flag::Interrupt,
-      ).unwrap();
+        &[signalbool::Signal::SIGINT], signalbool::Flag::Restart,
+    ).unwrap();
 
     match direction {
         Rx => {


### PR DESCRIPTION
Inspired by https://github.com/kevinmehall/rust-soapysdr/pull/29 but uses signalbool's Windows-compatible `Flag::Restart` instead of replacing it with another library. Includes commits from https://github.com/kevinmehall/rust-soapysdr/pull/28.