### PR TITLE
Add TxStream::read_status

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1136,7 +1136,32 @@ impl<E: StreamSample> TxStream<E> {
         Ok(())
     }
 
-    // TODO: read_status
+    /// Read the status of the stream.
+    /// 
+    /// This is required to detect underflows and such as they are not reported by 
+    /// [write](TxStream::write).
+    /// 
+    /// `chan_mask``, `flags``, and `time_ns`` are output parameters and _may_ be 
+    /// set depending on the type of status result.
+    /// 
+    /// Returns the status `Result`, usually this will be an [Error], as would be 
+    /// returned from a stream read/write.
+    /// 
+    /// [ErrorCode::Timeout] should generally be ignored.
+    pub fn read_status(&mut self, chan_mask: &mut usize, flags: &mut i32, time_ns: &mut i64, timeout_us: i64) -> Result<usize, Error> {
+        unsafe {
+            let status = len_result(SoapySDRDevice_readStreamStatus(
+                self.device.inner.ptr,
+                self.handle,
+                chan_mask,
+                flags,
+                time_ns,
+                timeout_us
+            ))?;
+
+            Ok(status as usize)
+        }
+    }
 
     // TODO: DMA
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -1148,7 +1148,13 @@ impl<E: StreamSample> TxStream<E> {
     /// returned from a stream read/write.
     /// 
     /// [ErrorCode::Timeout] should generally be ignored.
+    /// 
+    /// Note that `timeout_us` is only `i32` on Windows and panics if the value is 
+    /// too large for `i32` on that platform.
     pub fn read_status(&mut self, chan_mask: &mut usize, flags: &mut i32, time_ns: &mut i64, timeout_us: i64) -> Result<usize, Error> {
+        // Conversion needed for Windows, which takes an i32 here for some reason.
+        #[allow(clippy::useless_conversion)]
+        let timeout_us = timeout_us.try_into().unwrap();
         unsafe {
             let status = len_result(SoapySDRDevice_readStreamStatus(
                 self.device.inner.ptr,


### PR DESCRIPTION
I needed this to be able to detect under-runs. I'm not sure if you had other ideas on how to handle the interface, but it works for me.