### PR TITLE
give a friendly error message to Windows users on build

### DIFF
--- a/soapysdr-sys/build.rs
+++ b/soapysdr-sys/build.rs
@@ -24,8 +24,15 @@ fn probe_pkg_config() -> Option<Vec<PathBuf>> {
         .atleast_version("0.6.0")
         .probe("SoapySDR")
     {
+        #[cfg(not(windows))]
+        // windows users likely don't have pkg_config installed, so
+        // this would be a confusing error message
         Err(e) => {
             eprintln!("pkg_config: {}", e);
+            None
+        }
+        #[cfg(windows)]
+        Err(_) => {
             None
         }
         Ok(lib) => Some(lib.include_paths),
@@ -57,11 +64,85 @@ fn probe_pothos_sdr() -> Option<Vec<PathBuf>> {
     None
 }
 
+fn panic_help_message_soapysdr() {
+    #[cfg(windows)]
+    {
+        const MSG: &str = "
+
+
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        SoapySDR (PothosSDR) is required but could not be found.
+        Please install PothosSDR from
+
+
+                https://downloads.myriadrf.org/builds/PothosSDR/
+
+                and select 'Add PothosSDR to the system PATH for all users'
+                or 'Add PothosSDR to the system PATH for the current user'
+
+        and then try again in a new command prompt.
+
+
+        Visit https://github.com/kevinmehall/rust-soapysdr for more information.
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+        ";
+        panic!("{}", MSG);
+    }
+    #[cfg(not(windows))]
+    {
+        panic!("SoapySDR is required but could not be found. Please install SoapySDR and try again.");
+    }
+}
+
+fn panic_help_message_libclang() {
+    #[cfg(windows)]
+    {
+        let msg = "
+
+
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        libclang (llvm) is required but could not be found.
+        Please install llvm from
+
+
+                https://releases.llvm.org/download.html
+
+                and select 'Add LLVM to the system PATH for all users'
+                or 'Add LLVM to the system PATH for the current user'
+
+
+        and then try again in a new command prompt.
+
+
+        Visit https://rust-lang.github.io/rust-bindgen/requirements.html for more information.
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+        ";
+        panic!("{}", msg);
+    }
+    #[cfg(not(windows))]
+    {
+        panic!("libclang is required but could not be found. Please install libclang and try again.");
+    }
+}
+
 fn main() {
     let include_paths = probe_env_var()
         .or_else(probe_pkg_config)
-        .or_else(probe_pothos_sdr)
-        .expect("Couldn't find SoapySDR");
+        .or_else(probe_pothos_sdr);
+
+    if include_paths.is_none() {
+        panic_help_message_soapysdr();
+    }
+
+    let include_paths = include_paths.unwrap();
+
+    if let Err(_) = std::panic::catch_unwind(|| bindgen::clang_version()) {
+        panic_help_message_libclang();
+    }
 
     let mut bindgen_builder = bindgen::Builder::default()
         .trust_clang_mangling(false)


### PR DESCRIPTION
If users encounter this package via `cargo`, they may not see the project's README. We can help nudge them in the right direction to get the build working.