### PR TITLE
feat: expose ArgType

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod args;
 pub use args::{Args, ArgsIterator};
 
 mod arginfo;
-pub use arginfo::ArgInfo;
+pub use arginfo::{ArgInfo, ArgType};
 
 mod device;
 pub use device::{Device, Direction, Error, ErrorCode, Range, RxStream, TxStream, enumerate};


### PR DESCRIPTION
Hi there! I'm using rust-soapysdr in a WebAssembly project, which means I'm converting data types back and forth between Rust types and WebAssembly types and need access to the ArgType struct. Thanks in advance!